### PR TITLE
fix pnpm waiting for 'Running install script ...'

### DIFF
--- a/os/windows/install.bat
+++ b/os/windows/install.bat
@@ -41,4 +41,4 @@ IF EXIST "%~dp0install.js" (GOTO :EXISTING) ELSE GOTO :MISSING
   ECHO To run the installer, please first unzip the archive
 
 :COMMON
-  PAUSE
+  ECHO .. Done

--- a/os/windows/uninstall.bat
+++ b/os/windows/uninstall.bat
@@ -24,5 +24,4 @@ RMDIR /Q /S "%LocalAPPData%\com.add0n.node"
 echo.
 echo ^>^>^> Done! ^<^<^<
 echo.
-pause
 


### PR DESCRIPTION
pnpm install -g native-client

before
```log
Packages: +1
+
Progress: resolved 1, reused 0, downloaded 1, added 1, done
.pnpm/native-client@1.0.3/node_modules/native-client: Running install script ...
```
after
```log
Progress: resolved 1, reused 0, downloaded 1, added 1, done
.pnpm/native-client@1.0.3/node_modules/native-client: Running install script, done in 240ms
C:\Users\username\AppData\Local\pnpm\global\5:
+ native-client 1.0.3
```